### PR TITLE
Add bless to split CSS for IE9

### DIFF
--- a/package.js
+++ b/package.js
@@ -14,7 +14,8 @@ Package.registerBuildPlugin({
   npmDependencies: {
     "source-map": "0.5.3",
     "postcss": "5.0.19",
-    "autoprefixer": "6.3.6"
+    "autoprefixer": "6.3.6",
+    "bless": "4.0.3"
   },
   sources: [
     'plugin/minify-css.js'

--- a/plugin/minify-css.js
+++ b/plugin/minify-css.js
@@ -5,7 +5,6 @@ var autoprefixer  = Npm.require('autoprefixer');
 var postcss       = Npm.require('postcss');
 var Future        = Npm.require('fibers/future');
 var bless         = Npm.require('bless');
-var combineSrcMap = Npm.require('combine-source-map');
 var path = Plugin.path;
 var fs = Npm.require('fs');
 var configpath = path.join(process.cwd(),'postcss.json');


### PR DESCRIPTION
All CSS beyond the 4095th selector is being ignored in IE9. Therefore, there is BlessCSS.
Couldn't get source maps to work again though. Maybe you could take a look at that :)
