### PR TITLE
Use latest available minifier-css version

### DIFF
--- a/package.js
+++ b/package.js
@@ -9,7 +9,7 @@ Package.describe({
 Package.registerBuildPlugin({
   name: "minifyStdCSS",
   use: [
-    'minifier-css@1.3.1'
+    'minifier-css'
   ],
   npmDependencies: {
     "source-map": "0.5.6",


### PR DESCRIPTION
Fixes an issue in Meteor 1.8 (https://github.com/meteor/meteor/issues/10253) where a @babel/runtime related message is erroneously shown. Should be backward-compatible with previous versions of Meteor.